### PR TITLE
New Filesystem Paths

### DIFF
--- a/docs/filesystems-file-transfer/filesystems.md
+++ b/docs/filesystems-file-transfer/filesystems.md
@@ -4,7 +4,7 @@ Large HPC systems often have different filesystems for different purposes. ORCD 
 
 ## Engaging
 
-Users each get a Home Directory that is backed up and meant for important files. An additional larger Pool space is provided for storing larger datasets longer term. Larger Scratch space is not backed up. [Additional storage can be purchased](project-filesystems.md), and PIs can request an additional 5TB of shared Pool storage for their lab. The Scratch spaces are meant for data used in actively running jobs, it will be faster to access during your job for the majority of workloads, but are not backed up and should not be used for long term storage. Any files that cannot be easily replaced should be stored in Home or Pool storage, or back up outside of Engaging.
+Users each get a Home Directory that is backed up and meant for important files. An additional larger Pool space is provided for storing larger datasets longer term. Larger Scratch space is not backed up. [Additional storage can be purchased](project-filesystems.md), and PIs can request an additional 5TB of shared Pool storage for their lab. The Scratch spaces are meant for data used in actively running jobs. It will be faster to access Scratch during your job for the majority of workloads, but it is not backed up and should not be used for long term storage. Any files that cannot be easily replaced should be stored in Home or Pool storage, or backed up outside of Engaging.
 
 See the table below for a description of each storage space. If your account was created before January 2025 and has not yet been migrated to the new storage, select the second tab.
 

--- a/docs/filesystems-file-transfer/filesystems.md
+++ b/docs/filesystems-file-transfer/filesystems.md
@@ -4,13 +4,34 @@ Large HPC systems often have different filesystems for different purposes. ORCD 
 
 ## Engaging
 
-Users each get a small home directory that is backed up and meant for important files. Larger scratch space is not backed up. [Additional storage can be purchased](project-filesystems.md). The Lustre scratch space will be faster than NFS for the majority of workloads, however having large numbers of small files will make it slower than NFS and can slow down the filesystem overall, so it is important to follow the [Lustre Best Practices](https://engaging-web.mit.edu/eofe-wiki/best_practices/lustre/). See the [Engaging Documentation Page on Storage](https://engaging-web.mit.edu/eofe-wiki/storage/) for more information.
+Users each get a Home Directory that is backed up and meant for important files. An additional larger Pool space is provided for storing larger datasets longer term. Larger Scratch space is not backed up. [Additional storage can be purchased](project-filesystems.md), and PIs can request an additional 5TB of shared Pool storage for their lab. The Scratch spaces are meant for data used in actively running jobs, it will be faster to access during your job for the majority of workloads, but are not backed up and should not be used for long term storage. Any files that cannot be easily replaced should be stored in Home or Pool storage, or back up outside of Engaging.
 
-| Storage Type      | Path | Quota | Backed up | Purpose/Notes |
-| ----------- | ----------- |----------- |----------- |----------- |
-| Home Directory <br> NFS  | `/home/<username>` | 100 GB | Backed up | Use for important files |
-| Lustre | `/nobackup1/<username>` | 1 TB | Not backed up | Scratch space <br> Faster than NFS |
-| NFS | `/pool001/<username>` | 1 TB | Not backed up | Scratch space |
+See the table below for a description of each storage space. If your account was created before January 2025 and has not yet been migrated to the new storage, select the second tab.
+
+=== "Account Created or Migrated After Jan 2025"
+    | Storage Type      | <div style="width:18em">Path</div> | Quota | Backed up | Purpose/Notes |
+    | ----------- | ----------- |----------- |----------- |----------- |
+    | Home Directory <br> Flash  | `/home/<username>` | 200 GB | Backed up with snapshots | Use for important files and software |
+    | Pool <br> Hard Disk | `/home/<username>/orcd/c7/pool` | 1 TB | Disaster recovery backup | Storing larger datasets |
+    | Scratch <br> Flash | `/home/<username>/orcd/c7/scratch` | 4 TB | **Not backed up** | Scratch space for I/O heavy jobs |
+
+    !!! warning  "Scratch is Not Backed Up"
+        Scratch is meant for temporary storage while running compute jobs. It is not meant for long term storage and **is not backed up**. **If you have not logged in for 6 months files in scratch will be deleted**. Any files that you would like to keep long-term should be copied onto another storage location with backup.
+=== "Account Created Before Jan 2025 or Not Yet Migrated"
+    | Storage Type      | <div style="width:12em">Path</div> | Quota | Backed up | Purpose/Notes |
+    | ----------- | ----------- |----------- |----------- |----------- |
+    | Home Directory <br> NFS  | `/home/<username>` | 100 GB | Backed up | Use for important files |
+    | NFS | `/pool001/<username>` | 1 TB | Not backed up | Scratch space |
+    | Lustre | `/nobackup1/<username>` | 1 TB | Not backed up | Scratch space <br> Heavy I/O jobs with few, large files |
+
+    !!! warning  "Lustre /nobackup1 is Not Backed Up"
+        /nobackup1 is meant for temporary storage while running compute jobs. It is not meant for long term storage and **is not backed up**. Any files that you would like to keep long-term should be copied onto another storage location with backup.
+
+    !!! note "Lustre /nobackup1 performs best with fewer, larger files"
+        Having large numbers of small files will make Lustre slower than NFS and can slow down the filesystem overall, so it is important to follow the [Lustre Best Practices](lustre-best-practices.md).
+
+
+
 
 ## Satori
 

--- a/docs/filesystems-file-transfer/lustre-best-practices.md
+++ b/docs/filesystems-file-transfer/lustre-best-practices.md
@@ -1,0 +1,45 @@
+# Lustre Best Practices
+
+!!! note "Lustre will be Retired"
+    We are in the process of migrating all lustre storage to a new flash Scratch filesystem. This page applies if you still have storage on `/nobackup1`. While these are all good general best practices, not everything on this page is relevant to the new Scratch storage.
+
+Lustre is a type of file system technology used on the engaging cluster, known to most users as the `/nobackup1b` or `/nobackup1c` file systems. The Lustre storage system is built to manage extremely high rates of input and output, and can read and write large files faster than traditional storage like NFS, the home directory.
+
+Since it is designed to read and write large files, it has difficulties running jobs that read and write lots of small files. When Lustre is faced with many small file input and output, it can get overloaded and in return responds very slowly across the entire filesystem, effecting more than just the user who is running the job with small file input and output.
+
+Along with avoiding small file input and output, there are a few other things users should know to avoid when using the Lustre file system (`nobackup1b`/`nobackup1c`)
+
+## Avoid using the command `ls -l`
+
+The `ls -l` command displays a lot of information such as ownership, permissions, and the size of files and directories. Some of this information, such as the file size, is only stored in part of the Lustre technology, and so this information must be queried for all files and directories on the file system. This can be very resource consuming and take a long time to complete since many files are stored on `/nobackup1b` and `/nobackup1c` by many users.
+
+Instead of using `ls -l`, you should:
+
+- Use `ls` by itself if you just want to see if a file exists
+- Use `ls -l <filename>` if you want the long listing of a specific file
+
+## Avoid having a Large Number of Files in a Single Directory
+
+Opening a file keeps a lock on the parent directory. When many files in the same directory are to be opened, it creates contention. A better practice is to split a large number of files (in the thousands or more) into multiple subdirectories to minimize contention.
+
+## Avoid Storing and Accessing Small Files on Lustre
+
+Accessing small files on the Lustre filesystem is not efficient. There are 2 other locations users can store smaller sized files that are much better suited to handle them. These locations are Pool and the user’s Home Directory. For more information on these storage locations, please see the page on [General Use Filesystems](filesystems.md).
+
+To limit users storing lots of small files on `/nobackup1b` or `/nobackup1c`, there is a inode quota of 50k on these locations. An inode is a file, directory, or symlink, since all *unix systems treat these inodes the same in terms of permissions and storage.
+
+To check how much of your quota you have used, you can use the command:
+
+```bash
+lfs quota -h -u <username> /nobackup1
+```
+
+## Avoid Accessing and Running Executable Files from Lustre
+
+Executables run slower when they are run from `/nobackup1`, and shouldn’t be run from login or head nodes, regardless if they are ran from `/nobackup1`, Pool, or a user’s Home Directory. To learn how to run on Engaging, see the section on [Running Jobs](../running-jobs/overview.md).
+
+Executable files for jobs are best stored in a user’s home directory. Storing executable files in Pool is also acceptable, but less ideal. Input data, such as datasets or input files, can be stored on `/nobackup1` and your job can generate any large data output to `/nobackup1`. Any files you need to keep long term should also be stored in Home, Pool, or another backed up location. Anything stored in a location that is not backed up, such as `/nobackup1`, has some risk of being lost.
+
+## Avoid Having Multiple Processes Open the Same File(s) at the Same Time
+
+On Lustre filesystems, if multiple processes try to open the same file(s), some processes will not able to find the file(s) and your job will fail.


### PR DESCRIPTION
Adding paths to storage for newer accounts and accounts that have been migrated. Also included the Lustre Best Practices page from old docs for those still on /nobackup. It can be removed later.