### PR TITLE
WIP: Cursor add Rclone Recipe for Cloud/S3 Archiving

### DIFF
--- a/docs/recipes/rclone.md
+++ b/docs/recipes/rclone.md
@@ -1,0 +1,46 @@
+---
+tags:
+ - Rclone
+ - Archiving
+ - Storage
+ - Best Practices
+---
+
+# Using Rclone for Data Archiving
+
+Rclone is a powerful command-line tool for managing files on cloud storage and other remote storage systems. It functions like rsync for cloud storage, allowing you to efficiently copy, sync, and manage data across various storage destinations. On the Engaging cluster, rclone provides researchers with a convenient way to archive their data to long-term storage or share data with collaborators.
+
+This recipe will guide you through setting up and using rclone on Engaging to archive data to several popular storage destinations.
+
+## Getting Rclone on Engaging
+
+*This section will cover how to access rclone on Engaging (either through module loading or installation).*
+
+## MIT Account Google Drive
+
+*This section will provide step-by-step instructions for configuring and using rclone with MIT Google Drive.*
+
+## MIT Account Dropbox
+
+*This section will provide step-by-step instructions for configuring and using rclone with MIT Dropbox.*
+
+## AWS S3 Bucket
+
+*This section will provide step-by-step instructions for configuring and using rclone with AWS S3.*
+
+## NSF ACCESS Open Storage Network
+
+*This section will provide step-by-step instructions for configuring and using rclone with the ACCESS Open Storage Network.*
+
+## Best Practices
+
+*This section will cover best practices for efficient and safe data archiving with rclone.*
+
+## Troubleshooting
+
+*This section will help resolve common issues when using rclone.*
+
+## Frequently Asked Questions
+
+*This section will answer common questions about using rclone on Engaging.*
+


### PR DESCRIPTION
## 🚧 Work in Progress

This PR adds a comprehensive recipe for using rclone on the Engaging cluster to archive data to various storage destinations.

## Storage Destinations to Cover
- [ ] MIT Account Google Drive
- [ ] MIT Account Dropbox  
- [ ] AWS S3 buckets
- [ ] NSF ACCESS Open Storage Network (OSN)

## Progress Checklist
- [x] Initial file structure created
- [ ] Research completed
- [ ] Installation/setup section
- [ ] Google Drive section
- [ ] Dropbox section  
- [ ] AWS S3 section
- [ ] OSN section
- [ ] Example scripts
- [ ] Best practices section
- [ ] Troubleshooting section
- [ ] FAQs section
- [ ] Navigation updated
- [ ] Local build tested
- [ ] Ready for review

## Preview
After GitHub Actions complete, preview will be available at:
https://mit-orcd.github.io/orcd-docs-previews/PR/PR156

## Development Notes
This PR is being developed incrementally with commits pushed as sections are completed. Each push triggers a preview rebuild for continuous validation.

## Files
- `docs/recipes/rclone.md` - Main recipe documentation
- `docs/recipes/scripts/rclone/` - Example scripts (to be added)
- `mkdocs.yml` - Navigation entry (to be updated)