### PR TITLE
Testing Zensical

### DIFF
--- a/.github/workflows/pr-preview-artifact.yml
+++ b/.github/workflows/pr-preview-artifact.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: build
         run: |
-          mkdocs build
+          zensical build --clean 
 
       - name: show-pull-number
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build
 .DS_Store
 .local/
 sync-context.sh
+site

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.md": "python-markdown"
+  }
+}

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -4,6 +4,6 @@ If have used our system or consultation services and you would like to acknowled
 
 !!! quote "Acknowledgement Statement"
 
-    The authors acknowledge the MIT Office of Research Computing and Data for providing [high performance computing, consultation, data] resources that have contributed to the research results reported within this paper.
+    The authors acknowledge the MIT Office of Research Computing and Data for providing \[high performance computing, consultation, data] resources that have contributed to the research results reported within this paper.
 
 Thank you for acknowledging us – we appreciate it.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -155,7 +155,7 @@ It sometimes takes an extra bit of time for your account to be set up properly s
 
 ### I submitted a job to `mit_normal_gpu` and it's still pending in the queue. Why is it taking so long?
 
-This is most likely because there aren't enough resources available or other jobs are ahead of yours in the queue (see [Checking Job Status](running-jobs/overview/#checking-job-status)). To check what resources are available, use the `sinfo` command. This variation will show what GPU resources exist and are in use on each node in mit_normal_gpu:
+This is most likely because there aren't enough resources available or other jobs are ahead of yours in the queue (see [Checking Job Status](running-jobs/overview.md#checking-job-status)). To check what resources are available, use the `sinfo` command. This variation will show what GPU resources exist and are in use on each node in mit_normal_gpu:
 
 ```
 sinfo -O "Partition,Nodes:10,CPUsState,Gres:30,GresUsed:30,StateCompact" -e -p mit_normal_gpu

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ If you are using older Centos 7 nodes you can use one of the Centos 7 login node
 - `orcd-vlogin003`
 - `orcd-vlogin004`
 
-See [Logging in with SSH](accessing-orcd/ssh-login.md/#logging-in-via-ssh) for more information.
+See [Logging in with SSH](accessing-orcd/ssh-login.md) for more information.
 
 ### OnDemand
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,119 +1,118 @@
 # Glossary
 
 #### Apptainer / Singularity
-A container platform designed for high-performance computing (HPC) environments. It allows users to create and run containers that encapsulate their applications and dependencies, ensuring reproducibility and portability across different systems.
+:   A container platform designed for high-performance computing (HPC) environments. It allows users to create and run containers that encapsulate their applications and dependencies, ensuring reproducibility and portability across different systems.
 
 #### Batch Job
-A type of job submitted to the scheduler to run in the background without direct interactive supervision. These are typically used for longer-running programs and are submitted using a script.
+:   A type of job submitted to the scheduler to run in the background without direct interactive supervision. These are typically used for longer-running programs and are submitted using a script.
 
 #### Binary / Executable File
-A pre-built program file that can be run directly without needing to be compiled from source code. These are often placed in the `bin` directory of a software installation.
+:   A pre-built program file that can be run directly without needing to be compiled from source code. These are often placed in the `bin` directory of a software installation.
 
 #### CLI (Command Line Interface)
-A text-based user interface used to interact with software and operating systems by typing commands into a console or terminal.
+:   A text-based user interface used to interact with software and operating systems by typing commands into a console or terminal.
 
 #### Conda Environment
-A self-contained directory that includes a set of installed packages and libraries, managed by the Conda package manager. Conda is typically used to manage Python environments.
+:   A self-contained directory that includes a set of installed packages and libraries, managed by the Conda package manager. Conda is typically used to manage Python environments.
 
 #### Container
-A lightweight, standalone, and executable software package that includes everything needed to run a piece of software, including the code, runtime, libraries, and system tools. Containers are isolated from each other and the host system, allowing for consistent and reproducible environments across different computing platforms.
+:   A lightweight, standalone, and executable software package that includes everything needed to run a piece of software, including the code, runtime, libraries, and system tools. Containers are isolated from each other and the host system, allowing for consistent and reproducible environments across different computing platforms.
 
 #### Container Image
-A static file that contains the complete filesystem and configuration needed to run a containerized application. It serves as a blueprint for creating containers.
+:   A static file that contains the complete filesystem and configuration needed to run a containerized application. It serves as a blueprint for creating containers.
 
 #### Compute Node
-The primary nodes within an HPC cluster where the actual computational work of user jobs is performed.
+:   The primary nodes within an HPC cluster where the actual computational work of user jobs is performed.
 
 #### Computing Cluster
-A collection of interconnected computers (nodes) that work together to perform complex computations.
+:   A collection of interconnected computers (nodes) that work together to perform complex computations.
 
 #### CPU Core
-The smallest unit of processing on a node that can be used by a job. In HPC, jobs can request a specific number of CPU cores to perform parallel tasks.
+:   The smallest unit of processing on a node that can be used by a job. In HPC, jobs can request a specific number of CPU cores to perform parallel tasks.
 
 #### Engaging
-The main computing cluster managed by ORCD. This cluster is available to the entire MIT community and has a mixture of CPU and GPU resources.
+:   The main computing cluster managed by ORCD. This cluster is available to the entire MIT community and has a mixture of CPU and GPU resources.
 
 #### Environment
-The overall configuration and settings in which a program or job runs, including system variables, paths, and loaded modules.
+:   The overall configuration and settings in which a program or job runs, including system variables, paths, and loaded modules.
 
 #### Environment Variable
-Named values in your shell environment that store configuration information for the operating system and running programs. Examples include `$PATH` (which tells Linux where to look for executable files) or `$SLURM_ARRAY_JOB_ID` (set by the scheduler during job execution).
+:   Named values in your shell environment that store configuration information for the operating system and running programs. Examples include `$PATH` (which tells Linux where to look for executable files) or `$SLURM_ARRAY_JOB_ID` (set by the scheduler during job execution).
 
 #### Filesystem
-The method and structure by which files and directories are organized and stored on a computer. ORCD's clusters use a shared filesystem accessible by all nodes in the cluster.
+:   The method and structure by which files and directories are organized and stored on a computer. ORCD's clusters use a shared filesystem accessible by all nodes in the cluster.
 
 #### Globus
-A data management service that enables secure, reliable, and efficient transfer of files across multiple systems and locations.
+:   A data management service that enables secure, reliable, and efficient transfer of files across multiple systems and locations.
 
 #### GPU (Graphics Processing Unit)
-A specialized processor designed to accelerate graphics rendering and parallel processing tasks, commonly used in high-performance computing for tasks such as machine learning and simulations.
+:   A specialized processor designed to accelerate graphics rendering and parallel processing tasks, commonly used in high-performance computing for tasks such as machine learning and simulations.
 
 #### GUI (Graphical User Interface)
-A user interface that allows users to interact with electronic devices through graphical icons and visual indicators, as opposed to text-based interfaces, typed command labels, or text navigation.
+:   A user interface that allows users to interact with electronic devices through graphical icons and visual indicators, as opposed to text-based interfaces, typed command labels, or text navigation.
 
 #### Hard Disk Drive (HDD)
-A type of storage device that uses spinning disks to read and write data. HDDs are commonly used for bulk storage in HPC environments, but they are slower than SSDs in terms of data access and transfer speeds.
+:   A type of storage device that uses spinning disks to read and write data. HDDs are commonly used for bulk storage in HPC environments, but they are slower than SSDs in terms of data access and transfer speeds.
 
 #### Home Directory
-A personal directory allocated to each user on the cluster, located at `/home/$USER`. This is the default working directory for users when they log in.
+:   A personal directory allocated to each user on the cluster, located at `/home/$USER`. This is the default working directory for users when they log in.
 
 #### HPC (High-Performance Computing)
-The use of supercomputers and parallel processing techniques to solve complex computational problems that require significant processing power and memory.
+:   The use of supercomputers and parallel processing techniques to solve complex computational problems that require significant processing power and memory.
 
 #### Interactive Job
-A job that allows users to interact with the application or process while it is running, typically through a command line interface or graphical user interface.
+:   A job that allows users to interact with the application or process while it is running, typically through a command line interface or graphical user interface.
 
-<!-- CHECK -->
 #### I/O (Input/Output)
-The communication between a program and the filesystem, including reading from and writing to files. I/O performance can be a critical factor in the efficiency of HPC applications.
+:   The communication between a program and the filesystem, including reading from and writing to files. I/O performance can be a critical factor in the efficiency of HPC applications.
 
 #### Job
-A unit of work submitted to the scheduler (e.g., Slurm) to be executed on the compute nodes of an HPC cluster
+:   A unit of work submitted to the scheduler (e.g., Slurm) to be executed on the compute nodes of an HPC cluster
 
 #### Local Filesystem
-The storage system that is physically attached to a node, as opposed to shared or networked filesystems. Local filesystems typically offer faster access times but are limited to the storage capacity of the individual node.
+:   The storage system that is physically attached to a node, as opposed to shared or networked filesystems. Local filesystems typically offer faster access times but are limited to the storage capacity of the individual node.
 
 #### Login Node
-A specialized node within an HPC cluster that users first connect to via SSH or a web portal. It is intended for tasks like file editing, package installation, data downloads, and submitting jobs to compute nodes, but not for heavy computations.
+:   A specialized node within an HPC cluster that users first connect to via SSH or a web portal. It is intended for tasks like file editing, package installation, data downloads, and submitting jobs to compute nodes, but not for heavy computations.
 
 #### Memory
-The hardware component (such as RAM or cache) where data and applications are temporarily stored for active use by the processor. Data in memory is volatile and is lost when the computer is powered off or restarted.
+:   The hardware component (such as RAM or cache) where data and applications are temporarily stored for active use by the processor. Data in memory is volatile and is lost when the computer is powered off or restarted.
 
 #### Module
-A software tool that allows users to easily manage different versions of software, libraries, and compilers in a shared computing environment. Users can load or unload modules to configure their environment for specific tasks.
+:   A software tool that allows users to easily manage different versions of software, libraries, and compilers in a shared computing environment. Users can load or unload modules to configure their environment for specific tasks.
 
 #### MPI (Message Passing Interface)
-A standardized library of functions for parallel computing that enables data communication between processes running across multiple CPU cores or nodes. It's primarily used for distributed-memory parallelism, where each process has its own memory.
+:   A standardized library of functions for parallel computing that enables data communication between processes running across multiple CPU cores or nodes. It's primarily used for distributed-memory parallelism, where each process has its own memory.
 
 #### Node
-An individual computing unit within an HPC cluster, which can be a physical or virtual machine. Each node has its own CPU cores and memory.
+:   An individual computing unit within an HPC cluster, which can be a physical or virtual machine. Each node has its own CPU cores and memory.
 
 #### OpenMP
-A shared-memory parallelism technique where different parts of a program run concurrently as "threads" within a single process, sharing the same memory space. OpenMP is a common standard for implementing multithreading.
+:   A shared-memory parallelism technique where different parts of a program run concurrently as "threads" within a single process, sharing the same memory space. OpenMP is a common standard for implementing multithreading.
 
 #### Partition
-A logical grouping of compute nodes within an HPC cluster, managed by the scheduler (Slurm). Different partitions may have varying CPU types, GPU availability, memory limits, or time limits, and jobs are submitted to specific partitions.
+:   A logical grouping of compute nodes within an HPC cluster, managed by the scheduler (Slurm). Different partitions may have varying CPU types, GPU availability, memory limits, or time limits, and jobs are submitted to specific partitions.
 
 #### Pool storage
-A storage space on Engaging that is meant for handling large data sets but is not optimized for high I/O. Typically, pool storage is hosted on HDDs.
+:   A storage space on Engaging that is meant for handling large data sets but is not optimized for high I/O. Typically, pool storage is hosted on HDDs.
 
 #### Process
-An instance of a running program, which can consist of one or more threads. Each process has its own memory space.
+:   An instance of a running program, which can consist of one or more threads. Each process has its own memory space.
 
 #### Python Virtual Environment
-A self-contained directory that includes a set of installed Python packages. This allows users to manage dependencies and avoid conflicts between different projects.
+:   A self-contained directory that includes a set of installed Python packages. This allows users to manage dependencies and avoid conflicts between different projects.
 
 #### Scratch Storage
-Temporary, high-speed storage areas optimized for I/O-heavy jobs. Data stored here is typically not backed up and is meant for actively running jobs rather than long-term storage. Scratch storage is hosted on SSDs.
+:   Temporary, high-speed storage areas optimized for I/O-heavy jobs. Data stored here is typically not backed up and is meant for actively running jobs rather than long-term storage. Scratch storage is hosted on SSDs.
 
 #### Slurm / Scheduler
-An open-source workload manager designed for high-performance computing (HPC) clusters. It is used to allocate resources, schedule jobs, and manage job queues on the cluster.
+:   An open-source workload manager designed for high-performance computing (HPC) clusters. It is used to allocate resources, schedule jobs, and manage job queues on the cluster.
 
 #### Solid State Drive (SSD)
-A type of storage device that uses flash memory to provide faster data access and improved reliability compared to traditional hard disk drives (HDDs).
+:   A type of storage device that uses flash memory to provide faster data access and improved reliability compared to traditional hard disk drives (HDDs).
 
 #### Terminal / Shell / Command Line / Console
-A text-based interface used to interact with the operating system and run commands.
+:   A text-based interface used to interact with the operating system and run commands.
 
 #### Thread
-A smaller unit of a process that can run concurrently with other threads within the same process, sharing the same memory space.
+:   A smaller unit of a process that can run concurrently with other threads within the same process, sharing the same memory space.

--- a/docs/recipes/openclaw-engaging.md
+++ b/docs/recipes/openclaw-engaging.md
@@ -56,7 +56,7 @@ directory. All agent state is stored in `.openclaw/` next to the repo, so it
 survives job preemptions.
 
 You access the web dashboard from your laptop via an SSH tunnel through a login
-node, similar to the [port forwarding approach used for Jupyter](jupyter.md#port-forwarding).
+node.
 
 ```
 Your laptop (browser)

--- a/docs/services/accessing-group-resources.md
+++ b/docs/services/accessing-group-resources.md
@@ -4,7 +4,7 @@ Individual group storage and hardware resources are configured so that access is
 of accounts belonging to a Moira list that is defined for the group
 storage. The owner and administrators of group storage can manage
 access themselves by modifying the membership of an associated moira list
-under **https://groups.mit.edu/webmoira/list/[list_name]**. The name of the
+under **https://groups.mit.edu/webmoira/list/\[list_name]**. The name of the
 list corresponds to a UNIX group name associated with your group's resources on Engaging. The naming scheme we use means this list name won't exactly match the UNIX group name you see on the system, but it will be similar.
 
 If you are an admin of an ORCD group you will see that group listed under "Lists I Can Administer" when you log into [Web Moira](https://groups.mit.edu/webmoira/). Any ORCD groups will start with "orcd_ug" and will contain the Kerberos ID of the PI, or a short name for your DLCI or project. Click on the group name to go to the group management page. We will also send you a direct link to your group management page when we create your group.

--- a/docs/services/hosted-hardware.md
+++ b/docs/services/hosted-hardware.md
@@ -27,7 +27,7 @@ Scientists may specify the configuration of their partitions within reason. Gene
 
 Once the nodes have been tested, they are released for use. You may grant users access via MIT Moira. Your new nodes will have access controlled by your user group. To give users access to your nodes, the corresponding usergroup must be modified. For example: 
 
-orcd_ug_pi_[pikerb]_all
+orcd_ug_pi_\[pikerb]_all
 
 
 You can make the additions here on the [WebMoira page](https://groups.mit.edu/webmoira/). See [Accessing Group Resources](accessing-group-resources.md) for more information.

--- a/docs/software/R.md
+++ b/docs/software/R.md
@@ -93,7 +93,7 @@ You should now see printed instructions for setting up port forwarding to intera
 
 Similar to RStudio, Jupyter notebooks offer a handy cell-based interface to run R code. You can run R on Jupyter notebooks through the Engaging web portal.
 
-Jupyter notebooks are available through [ORCD OnDemand](https://orcd-ood.mit.edu) > Interactive Apps > Jupyter Notebook. To run R, you must create a Conda environment with both `r-irkernel` and `jupyterlab` installed (see [R with Conda](#r-with-conda) and [Jupyter](../recipes/jupyter.md#r)). When starting up the notebook, enter the name of your custom Conda environment. Once you launch the session and open your notebook, you may need to change your kernel to R. Your current kernel is shown in the top right, and likely defaults to "Python 3 (ipykernel)". Click this to change it to R.
+Jupyter notebooks are available through [ORCD OnDemand](https://orcd-ood.mit.edu) > Interactive Apps > Jupyter Notebook. To run R, you must create a Conda environment with both `r-irkernel` and `jupyterlab` installed (see [R with Conda](#r-with-conda) and [Jupyter](../recipes/jupyter.md#language-specific-instructions)). When starting up the notebook, enter the name of your custom Conda environment. Once you launch the session and open your notebook, you may need to change your kernel to R. Your current kernel is shown in the top right, and likely defaults to "Python 3 (ipykernel)". Click this to change it to R.
 
 ## FAQs
 

--- a/docs/software/building-software.md
+++ b/docs/software/building-software.md
@@ -15,12 +15,12 @@ Software compilation workflows will vary based on the software and its dependenc
     There can be a lot of moving parts when building software, and it's easy to forget where or what you installed, so it is helpful to stay organized. We recommend a directory structure that looks like this:
 
     - $HOME/software - A directory called "software" to keep all your builds
-        - [software_name] - The name of the software
-            - [source_code] - The directory of source code you downloaded
+        - \[software_name] - The name of the software
+            - \[source_code] - The directory of source code you downloaded
             - install - For the installation files
             - deps - For any dependencies needed to build your software
-                - [dep1_src] - Downloaded source for dependency 1
-                - [dep2_src] - Downloaded source for dependency 2
+                - \[dep1_src] - Downloaded source for dependency 1
+                - \[dep2_src] - Downloaded source for dependency 2
                 - install - Directory for all dependency installs so they are in one place
 
 
@@ -51,7 +51,7 @@ Builds are not too computationally heavy, but tend to run more slowly on the log
 ```bash
 salloc -p mit_normal -c 4
 ```
-This will allocate 1 node from the `mit_normal` partition with 4 CPUs for compiling your software. You will receive output that your request for allocation has been submitted, and when a node has been allocated for you to use, it will say “[Node_name] are ready for job”.
+This will allocate 1 node from the `mit_normal` partition with 4 CPUs for compiling your software. You will receive output that your request for allocation has been submitted, and when a node has been allocated for you to use, it will say “\[Node_name] are ready for job”.
 
 !!! Note
     Be sure to request the partition you intend to run your jobs on. The node you build on will need to match the operating system of the nodes you plan to run your jobs on.
@@ -84,7 +84,7 @@ First go to the directory that contains the `configure` script. When you run `co
 ./configure --prefix=$HOME/[install_directory]
 ```
 
-where ‘install_directory’ is the directory where you would like the software to be installed to. If you plan to install multiple pieces of personal software, we recommend making a folder entitled ``software` in your home directory and installing software there. We like to use the path `/home/$USER/software/[software_name]/install` where `[software_name]` is the name of your software. The `install` directory is there to differentiate from any source code that may be stored in the same location. If you keep the source code elsewhere you can leave off `install` from the path.
+where ‘install_directory’ is the directory where you would like the software to be installed to. If you plan to install multiple pieces of personal software, we recommend making a folder entitled `software` in your home directory and installing software there. We like to use the path `/home/$USER/software/[software_name]/install` where `[software_name]` is the name of your software. The `install` directory is there to differentiate from any source code that may be stored in the same location. If you keep the source code elsewhere you can leave off `install` from the path.
 
 ### Running `cmake`
 

--- a/docs/software/overview.md
+++ b/docs/software/overview.md
@@ -45,4 +45,4 @@ For [Python](python.md), [Julia](julia.md), and [R](R.md) packages, each of thes
 
 ### Ask for Help
 
-If you are having trouble installing software you can reach out to <orcd-help@mit.edu> or one of the other lists on [Getting Help](../getting-help.md#email) for help. You can also stop by [office hours](../getting-help.md/#office-hours) if you prefer. Depending on the software and the system you are using, we may help walk you through installing it for yourself or install it in a community location.
+If you are having trouble installing software you can reach out to <orcd-help@mit.edu> or one of the other lists on [Getting Help](../getting-help.md#email) for help. You can also stop by [office hours](../getting-help.md#office-hours) if you prefer. Depending on the software and the system you are using, we may help walk you through installing it for yourself or install it in a community location.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,17 +69,39 @@ nav:
   - Getting Help: getting-help.md
   - FAQs: faqs.md
   - Glossary: glossary.md
-  - Index: tags.md
+#  - Index: tags.md
 
 theme: 
   name: material
-  variant: classic
+  variant: modern
   logo: images/ORCD_logo_icononly.png
   features:
     - content.code.copy
     - content.tabs.link
+    - content.tooltips
   palette:
-    primary: blue grey
+
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: lucide/sun-moon
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      primary: blue grey
+      toggle:
+        icon: lucide/sun
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      primary: blue grey
+      scheme: slate
+      toggle:
+        icon: lucide/moon
+        name: Switch to system preference
 plugins:
   - search
   - tags:
@@ -88,20 +110,23 @@ plugins:
   - open-in-new-tab
   - table-reader
 markdown_extensions:
+  - def_list
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - zensical.extensions.macros
+  #    on_error_fail: true
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
-  - pymdownx.inlinehilite
   - pymdownx.snippets:
       url_download: true
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true 
-  - admonition
-  - pymdownx.details
   - toc:
       permalink: True
-  - attr_list
-  - admonition
+
 copyright: <a href="https://accessibility.mit.edu/">Accessibility</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
 
 theme: 
   name: material
+  variant: classic
   logo: images/ORCD_logo_icononly.png
   features:
     - content.code.copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 zensical
+pandas
+tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-mkdocs-material
-mkdocs-git-revision-date-localized-plugin
-mkdocs-open-in-new-tab
-mkdocs-table-reader-plugin
+zensical


### PR DESCRIPTION
Mkdocs may not support Material in the future, so I am trying out [Zensical](https://zensical.org/), which the Material developers have created as a replacement. This PR is trying it out.

Features that are not yet supported that we use:

- [ ] Currently [Tag Listings](https://zensical.org/docs/setup/tags/#configuration) are not supported, which breaks our Index page.
- [ ] Outside links are no longer opening in a new tab. Currently using open-in-tab plugin, this may be supported by [privacy](https://github.com/zensical/backlog/issues/35) plugin.
- [ ] [git-revision-date](https://github.com/zensical/backlog/issues/18)